### PR TITLE
Export a React provider for managing user and authentication state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @getmocha/users-service
 
-An SDK for interacting with the Mocha Users Service, providing authentication and user management functionality for Hono applications.
+An SDK for interacting with the Mocha Users Service, providing authentication and user management functionality for Hono and React applications.
 
 ## Installation
 
@@ -14,10 +14,11 @@ npm install @getmocha/users-service
 - Session management
 - User information retrieval
 - Hono middleware for protected routes
+- A React context provider and associated hook for managing user and authentication state in React apps.
 
 ## Usage
 
-### Authentication Flow
+### Backend Authentication Flow
 
 Use the @getmocha/users-service/backend export for backend functionality and Hono support.
 
@@ -150,4 +151,31 @@ type Variables = {
 };
 
 const app = new Hono<{ Bindings: Env; Variables: Variables }>();
+```
+
+### Frontend React package
+
+Use the @getmocha/users-service/react export for a React context provider and hook that provides user and authentication management.
+
+```tsx
+import { AuthProvider } from '@getmocha/users-service/react';
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/auth/callback" element={<AuthCallbackPage />} />
+        </Routes>
+      </Router>
+    </AuthProvider>
+  );
+}
+```
+
+Then you can use the exported `useAuth` hook.
+
+```tsx
+const { user, loadUser, redirectToUrl, logout, exchangeCodeForSessionToken } = useAuth();
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,38 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@types/react": "^18.0.0",
         "hono": "^4.8.0",
         "prettier": "^3.5.3",
+        "react": "^18.0.0",
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "hono": "^4.0.0"
+        "hono": "^4.0.0",
+        "react": "^18.0.0"
       }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/hono": {
       "version": "4.8.0",
@@ -24,6 +49,24 @@
       "dev": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/prettier": {
@@ -39,6 +82,18 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getmocha/users-service",
   "version": "0.0.2",
-  "description": "An API client and Hono middleware for the Mocha Users Service",
+  "description": "An API client, Hono middleware, and a React provider for the Mocha Users Service",
   "author": "Mocha (https://getmocha.com)",
   "license": "Apache-2.0",
   "type": "module",
@@ -9,6 +9,9 @@
     "*": {
       "backend": [
         "./dist/backend.d.ts"
+      ],
+      "react": [
+        "./dist/react.d.ts"
       ],
       "shared": [
         "./dist/shared.d.ts"
@@ -19,6 +22,10 @@
     "./backend": {
       "import": "./dist/backend.js",
       "types": "./dist/backend.d.ts"
+    },
+    "./react": {
+      "import": "./dist/react.js",
+      "types": "./dist/react.d.ts"
     },
     "./shared": {
       "import": "./dist/shared.js",
@@ -47,11 +54,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "react": "^18.0.0"
   },
   "devDependencies": {
+    "@types/react": "^18.0.0",
     "hono": "^4.8.0",
     "prettier": "^3.5.3",
+    "react": "^18.0.0",
     "typescript": "^5.8.3"
   }
 }

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -1,0 +1,183 @@
+import { createContext, useCallback, useContext, useRef, useState } from 'react';
+import type { MochaUser } from '@getmocha/users-service/shared';
+
+export interface AuthContextValue {
+  /**
+   * The currently authenticated user from the Mocha Users Service, or null if not authenticated.
+   * Use this both for checking authentication status and accessing user data.
+   */
+  user: MochaUser | null;
+
+  /**
+   * Makes a GET request to /api/users/me to get the current user.
+   * If the user is authenticated, the `user` object will be updated
+   * with the current user's data. Otherwise, `user` will be `null`.
+   */
+  loadUser: () => Promise<void>;
+
+  /**
+   * Makes a GET request to /api/oauth/google/redirect_url to get the login redirect URL.
+   * It then redirects the user to the url returned in the response to initiate the OAuth flow.
+   */
+  redirectToLogin: () => Promise<void>;
+
+  /**
+   * Makes a POST request to /api/sessions with the exchange code in the request body.
+   * This function is expected to be used after the user completes the OAuth flow and is
+   * redirected back to /auth/callback?code=<exchange_code>. It expects a `code` query parameter
+   * in the URL. Use this only on the /auth/callback page. Once this function completes successfully,
+   * the user state will be updated with the currently authenticated user's data.
+   */
+  exchangeCodeForSessionToken: () => Promise<void>;
+
+  /**
+   * Makes a GET request to /api/logout to log the user out.
+   * The `user` object will be set to `null`.
+   */
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+/**
+ * A React context provider that manages authentication state and related actions.
+ * Install this at the top of the React component tree to provide authentication
+ * and user management functionality. This is needed for the `useAuth` hook to work.
+ *
+ * This provider does not call `loadUser` when mounted. You must explicitly call `loadUser` to
+ * initialize the current user and check authentication status.
+ *
+ * @example
+ * import { AuthProvider } from '@getmocha/users-service/react';
+ *
+ * // React Router example
+ * export default function App() {
+ *   return (
+ *     <AuthProvider>
+ *       <Router>
+ *         <Routes>
+ *           <Route path="/" element={<HomePage />} />
+ *           <Route path="/auth/callback" element={<AuthCallbackPage />} />
+ *         </Routes>
+ *       </Router>
+ *     </AuthProvider>
+ *   );
+ * }
+ */
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<MochaUser | null>(null);
+  const userRef = useRef<Promise<void> | null>(null);
+  const exchangeRef = useRef<Promise<void> | null>(null);
+
+  const loadUser = useCallback(async () => {
+    if (userRef.current) return userRef.current;
+
+    userRef.current = (async () => {
+      try {
+        const response = await fetch('/api/users/me');
+        if (response.ok) {
+          const userData = await response.json();
+          setUser(userData);
+        } else {
+          setUser(null);
+        }
+      } catch (error) {
+        console.error('Failed to fetch user:', error);
+        setUser(null);
+      }
+    })();
+
+    return userRef.current;
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      setUser(null);
+      await fetch('/api/logout');
+    } catch (error) {
+      console.error('Failed to logout:', error);
+    }
+  }, []);
+
+  const redirectToLogin = useCallback(async () => {
+    try {
+      const response = await fetch('/api/oauth/google/redirect_url');
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to get login redirect URL: API responded with HTTP status ${response.status}`
+        );
+      }
+
+      const { redirectUrl } = await response.json();
+      window.location.href = redirectUrl;
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  const exchangeCodeForSessionToken = useCallback(() => {
+    // Ensure we only exchange the code once. In dev, useEffect will run
+    // twice, so we need to reuse this promise to avoid multiple exchanges
+    // which would otherwise result in a failed request. The failed request
+    // sometimes causes the entire flow to break.
+    if (exchangeRef.current) return exchangeRef.current;
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get('code');
+
+    if (!code) {
+      throw new Error(
+        'Cannot exchange code for session token: no code provided in the URL search params.'
+      );
+    }
+
+    exchangeRef.current = (async (code: string) => {
+      try {
+        const response = await fetch('/api/sessions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ code }),
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            `Failed to exchange code for session token: API responded with HTTP status ${response.status}`
+          );
+        }
+
+        // Refetch user after successful code exchange to populate user state
+        await loadUser();
+      } catch (error) {
+        console.error(error);
+      }
+    })(code);
+
+    return exchangeRef.current;
+  }, [loadUser]);
+
+  const contextValue: AuthContextValue = {
+    user,
+    logout,
+    loadUser,
+    redirectToLogin,
+    exchangeCodeForSessionToken,
+  };
+
+  return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
+}
+
+/**
+ * A React hook that provides the AuthContextValue.
+ * @example
+ * const { user } = useAuth();
+ */
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within a AuthProvider');
+  }
+  return context;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
It's a bit tricky to know exactly the right boundaries between AI-generated auth code for Mocha apps and what we provide. The goal here is to provide objective functionality while making relatively few assumptions about the apps this will be used in (so, no presentational components, mostly no assumptions about URLs).