### PR TITLE
Load user on mount and provide loading states

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,5 +177,13 @@ export default function App() {
 Then you can use the exported `useAuth` hook.
 
 ```tsx
-const { user, loadUser, redirectToUrl, logout, exchangeCodeForSessionToken } = useAuth();
+const {
+  user,
+  isPending,
+  isFetching,
+  fetchUser,
+  redirectToUrl,
+  exchangeCodeForSessionToken,
+  logout,
+} = useAuth();
 ```


### PR DESCRIPTION
- rename loadUser to fetchUser
- fetchUser on mount
- Provide two loading states: isPending and isFetching (naming taken from tanstack query). The former is only true the first time we're loading user data on mount, the latter is true any time the user is being fetched
- Fix bug with not resetting userRef to null so user can be subsequently fetched