### PR TITLE
Support React 18 and 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "hono": "^4.0.0",
-    "react": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",


### PR DESCRIPTION
Getting this on base template without already installed react:

```
❯ npm i
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: mocha-app@0.0.0
npm error Found: react@19.0.0
npm error node_modules/react
npm error   react@"19.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer react@"^18.0.0" from @getmocha/users-service@0.0.3
npm error node_modules/@getmocha/users-service
npm error   dev @getmocha/users-service@"^0.0.3" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/ben/.npm/_logs/2025-07-01T11_42_39_929Z-eresolve-report.txt

npm error A complete log of this run can be found in: /Users/ben/.npm/_logs/2025-07-01T11_42_39_929Z-debug-0.log
```